### PR TITLE
Allow to select keyboard as emulated device

### DIFF
--- a/src/libretro.c
+++ b/src/libretro.c
@@ -152,6 +152,19 @@ void retro_set_input_state(retro_input_state_t input_state)
 
 void retro_init(void)
 {
+  static const struct retro_controller_description controllers[] = {
+    {"RetroPad", RETRO_DEVICE_JOYPAD},
+    {"Keyboard", RETRO_DEVICE_KEYBOARD},
+  };
+
+  static const struct retro_controller_info ports[] = {
+    {controllers, 2},
+    {controllers, 2},
+    {NULL, 0},
+  };
+
+  environ_cb(RETRO_ENVIRONMENT_SET_CONTROLLER_INFO, (void *)ports);
+  
   struct retro_input_descriptor desc[] = {
         { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_LEFT,  "Left" },
         { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_UP,    "Up" },


### PR DESCRIPTION
This pull request's aim is to allow the user to select the keyboard as an emulated device (issue #2)

This is useful for games that were designed to be played with the keyboard only, on platform that do not have a keyboard (such as android, etc.).

I only tested it on linux.